### PR TITLE
Process ENV_DIR.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,12 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
+if [ -d "$ENV_DIR" ]; then
+    for e in $(ls $ENV_DIR); do
+	export "$e=$(cat $ENV_DIR/$e)"
+    done
+fi
+
 # default to Bazel version 0.3.0
 if [[ ! -v BAZEL_VERSION ]]; then
   BAZEL_VERSION="0.3.0"


### PR DESCRIPTION
Environment variables won't be set unless we source them from ENV_DIR.
See https://devcenter.heroku.com/articles/buildpack-api#bin-compile.